### PR TITLE
Replace Dark Mode with DarkOrLight

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,7 +109,7 @@
 
 ## MacOS
 
-- [Dark Mode](https://github.com/sindresorhus/alfred-dark-mode) - Quickly toggle menu bar dark mode.
+- [DarkOrLight](https://github.com/BaksiLi/AlfredWorkflows/tree/master/Index/DarkOrLight) - Change macOS theme to Dark/Light with one click.
 - [macOS App Search](https://github.com/nkcmr/alfred-apple-app-search) - Search macOS app store.
 
 ## Music


### PR DESCRIPTION
I am writing to request change from [Dark Mode](https://github.com/sindresorhus/alfred-dark-mode) to [DarkOrLight](https://github.com/BaksiLi/AlfredWorkflows/tree/master/Index/DarkOrLight).

The former can merely change from Light to Dark Mode.

The latter, which is the one I suggest to replace with, can:
1. toggle the mode change (from Dark to Light or reverse)
1. change to specific mode by adding an argument after the keyword

Therefore I consider the latter is better than the former.

Regards.