### PR TITLE
Add Time Calculator workflow

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -237,6 +237,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [Bluetooth Switch](https://github.com/uchida/alfred-switch-bluetooth) - Quickly connect / disconnect Bluetooth devices.
 - [Syntax highlight code](https://github.com/importre/alfred-hl) - Highlight code in the clipboard using [highlight.js](https://highlightjs.org/).
 - [Tidy](https://github.com/importre/alfred-tidy) - Beautify JSON/XML in clipboard.
+- [Time Calculator](https://github.com/shura-v/alfred-time-calculator) - Evaluate natural time expressions like “3 days ago” or “next Monday”. Supports math, working days, and date ranges.
 - [Time Machine](http://www.packal.org/workflow/time-machine) - Inspect and control Time Machine.
 - [TimeZones](http://geekzone.philosophicalzombie.net/post/45823505821/alfred-workflow-timezones-a-customizable-world) - Displays a customised world clock.
 - [Toggle Hidden Files](http://www.packal.org/workflow/toggle-hidden-files) - Show and hide hidden system files in Finder with one click.


### PR DESCRIPTION
### Time Calculator – Powerful time expression parser for Alfred

Hi! 👋

This PR adds [Time Calculator](https://github.com/shura-v/alfred-time-calculator), a modern and actively maintained Alfred workflow for evaluating time expressions.

It supports:
- Natural language (e.g. `3 days ago`, `in 5 weekdays`)
- Math operations (`1h + 30m - 5s / 2`)
- Relative & absolute dates (`at August 1998`, `from Monday to Friday`)
- Duration formatting (`2 hours, 45 minutes`)
- Working days logic

This workflow significantly expands the capabilities of [alfred-date-calculator](https://github.com/LeEnno/alfred-date-calculator), which is no longer maintained.

Also available as CLI (`tc`) and Node.js module for scripting and automation.

Thanks for reviewing!
