### PR TITLE
feat: add Google Cloud Platform workflow

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -78,6 +78,7 @@ _Please read [contribution guidelines](contributing.md) before contributing._
 - [alfred-crates](https://github.com/FGRibreau/alfred-crates) - Workflow for searching Rust crates.
 - [String Operations](https://github.com/fatih-yavuz/alfred-string-operations) - Perform string manipulation to the clipboard content.
 - [alfred-fkill](https://github.com/SamVerschueren/alfred-fkill) - Fabulously search and kill processes.
+- [Google Cloud Platform](https://github.com/dineshgowda24/alfred-gcp-workflow) - Search Google Cloud Platform services and resources.
 
 ## Documentation
 


### PR DESCRIPTION
Adds the Google Cloud Platform workflow. I am the creator of it. 
I use this workflow daily, and many others have found it helpful as well. You can check the discussions here: https://news.ycombinator.com/item?id=44173667.
You can also read about why I built the workflow in the first place: https://dineshgowda.com/posts/supercharging-gcp-navigation-with-alfred/